### PR TITLE
METEOR on TMPFS depending on free memory

### DIFF
--- a/ansible/roles/common/tasks/ramfs.yml
+++ b/ansible/roles/common/tasks/ramfs.yml
@@ -17,7 +17,7 @@
   become: yes
   mount:
     fstype: tmpfs
-    opts: "nodev,nosuid,size={% if os_memory.stdout|int < 2000 %}200M{% else %}1000M{% endif %}"
+    opts: "nodev,nosuid,size=1000M"
     src: tmpfs
     path: "{{ ramfs_path }}"
     state: mounted

--- a/ansible/roles/common/templates/noaa-v2.conf.j2
+++ b/ansible/roles/common/templates/noaa-v2.conf.j2
@@ -42,6 +42,7 @@ METEOR_M2_ENABLE_BIAS_TEE="{% if meteor_m2_enable_bias_tee|lower == 'true' %}-T{
 METEOR_M2_GAIN={{ meteor_m2_gain }}
 METEOR_M2_SUN_MIN_ELEV={{ meteor_m2_sun_min_elevation }}
 METEOR_M2_SAT_MIN_ELEV={{ meteor_m2_sat_min_elevation }}
+METEOR_M2_MEMORY_TRESHOLD={{ meteor_m2_memory_threshold }}
 DELETE_AUDIO={{ delete_audio|lower }}
 FLIP_METEOR_IMG={{ flip_meteor_image|lower }}
 TZ_OFFSET={{ timezone_offset }}

--- a/config/settings.yml.sample
+++ b/config/settings.yml.sample
@@ -37,6 +37,8 @@ meteor_receiver: 'rtl_fm'
 #   <satellite_name>_gain - gain setting for specific satellite captures
 #   <satellite_name>_sun_min_elevation - threshold for sun elevation for specific satellite captures
 #   <satellite_name>_sat_min_elevation - threshold for sat elevation for specific satellite captures
+#   <satellite_name>_memory_threshold - for METEOR satellite, minimum free memory (MB) required to store pass in RAM
+
 noaa_15_schedule: true
 noaa_15_sdr_device_id: 0
 noaa_15_freq_offset: -6
@@ -68,6 +70,7 @@ meteor_m2_enable_bias_tee: true
 meteor_m2_gain: 7.7
 meteor_m2_sun_min_elevation: 6
 meteor_m2_sat_min_elevation: 30
+meteor_m2_memory_threshold: 600
 
 # how many days to schedule passes - note this MUST be an even integer,
 # and the current day counts as "1" - passes will be scheduled until midnight

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -72,6 +72,7 @@
       "minimum": 0,
       "maximum": 90
     },
+    "meteor_m2_memory_threshold":      { "type": "number" },
     "days_to_schedule_passes":         { "type": "number" },
     "delete_audio":                    { "type": "boolean" },
     "flip_meteor_image":               { "type": "boolean" },
@@ -185,6 +186,7 @@
     "meteor_m2_gain",
     "meteor_m2_sun_min_elevation",
     "meteor_m2_sat_min_elevation",
+    "meteor_m2_memory_threshold",
     "days_to_schedule_passes",
     "delete_audio",
     "flip_meteor_image",

--- a/scripts/receive_meteor.sh
+++ b/scripts/receive_meteor.sh
@@ -47,12 +47,17 @@ AUDIO_FILE_BASE="${METEOR_AUDIO_OUTPUT}/${FILENAME_BASE}"
 IMAGE_FILE_BASE="${IMAGE_OUTPUT}/${FILENAME_BASE}"
 IMAGE_THUMB_BASE="${IMAGE_OUTPUT}/thumb/${FILENAME_BASE}"
 
-in_mem=true
-SYSTEM_MEMORY=$(free -m | awk '/^Mem:/{print $2}')
-if [ "$SYSTEM_MEMORY" -lt 2000 ]; then
+# check if there is enough free memory to store pass on RAM
+FREE_MEMORY=$(free -m | grep Mem | awk '{print $4}')
+if [ "$FREE_MEMORY" -lt $METEOR_M2_MEMORY_TRESHOLD ]; then
   log "The system doesn't have enough space to store a Meteor pass on RAM" "INFO"
+  log "Free : ${FREE_MEMORY} Required : ${METEOR_M2_MEMORY_TRESHOLD}" "INFO"
   RAMFS_AUDIO_BASE="${METEOR_AUDIO_OUTPUT}/${FILENAME_BASE}"
   in_mem=false
+else
+  log "The system have enough space to store a Meteor pass on RAM" "INFO"
+  log "Free : ${FREE_MEMORY} Required : ${METEOR_M2_MEMORY_TRESHOLD}" "INFO"
+  in_mem=true
 fi
 
 FLIP=""

--- a/scripts/receive_meteor.sh
+++ b/scripts/receive_meteor.sh
@@ -51,12 +51,12 @@ IMAGE_THUMB_BASE="${IMAGE_OUTPUT}/thumb/${FILENAME_BASE}"
 FREE_MEMORY=$(free -m | grep Mem | awk '{print $4}')
 if [ "$FREE_MEMORY" -lt $METEOR_M2_MEMORY_TRESHOLD ]; then
   log "The system doesn't have enough space to store a Meteor pass on RAM" "INFO"
-  log "Free : ${FREE_MEMORY} Required : ${METEOR_M2_MEMORY_TRESHOLD}" "INFO"
+  log "Free : ${FREE_MEMORY} ; Required : ${METEOR_M2_MEMORY_TRESHOLD}" "INFO"
   RAMFS_AUDIO_BASE="${METEOR_AUDIO_OUTPUT}/${FILENAME_BASE}"
   in_mem=false
 else
   log "The system have enough space to store a Meteor pass on RAM" "INFO"
-  log "Free : ${FREE_MEMORY} Required : ${METEOR_M2_MEMORY_TRESHOLD}" "INFO"
+  log "Free : ${FREE_MEMORY} ; Required : ${METEOR_M2_MEMORY_TRESHOLD}" "INFO"
   in_mem=true
 fi
 
@@ -157,6 +157,11 @@ if [ "$METEOR_RECEIVER" == "rtl_fm" ]; then
                                     "direction"
     ${IMAGE_PROC_DIR}/thumbnail.sh 300 "${IMAGE_FILE_BASE}-polar-direction.png" "${IMAGE_THUMB_BASE}-polar-direction.png"
   fi
+
+  # how are we about memory usage at this point ?
+  FREE_MEMORY=$(free -m | grep Mem | awk '{print $4}')
+  RAMFS_USAGE=$(du -sh ${RAMFS_AUDIO} | awk '{print $1}')
+  log "Free memory : ${FREE_MEMORY} ; Total RAMFS usage : ${RAMFS_USAGE}" "INFO"
 
   if [ "$DELETE_AUDIO" = true ]; then
     log "Deleting audio files" "INFO"


### PR DESCRIPTION
To decide if a meteor pass is to be done storing files in tmpfs, we check at execution time is the free memory is above a configurable treshold (meteor_m2_memory_threshold, default 600MB).

